### PR TITLE
Add sample open banking CLI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,56 @@ Welcome to my profile! I'm passionate about **crypto trading** and **gaming**. I
 - 🎮 Playing and exploring new games.
 - 🌐 Keeping up with the latest apps and technologies.
 
-Thank you for visiting my profile! Let's connect and explore the exciting world of crypto and gaming together!
+---
+
+## 🏦 Sample Open Banking Aggregator
+
+This repository now includes a minimal open banking demonstration that aggregates account data from JSON providers and exposes it through a simple command line interface. It is intended for educational purposes and does not connect to real banks.
+
+### Project Layout
+
+```
+open_banking/
+├── __init__.py
+├── api.py
+├── data/
+│   └── demo_provider.json
+├── main.py
+├── models.py
+└── providers.py
+```
+
+### Running the Program
+
+1. **Create a virtual environment (optional but recommended):**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. **Run the CLI using the bundled demo data:**
+   ```bash
+   python -m open_banking.main open_banking/data/demo_provider.json
+   ```
+
+   You should see a table summarising the demo accounts.
+
+3. **Output the data as JSON instead of a table:**
+   ```bash
+   python -m open_banking.main open_banking/data/demo_provider.json --format json
+   ```
+
+4. **Filter results by provider:**
+   ```bash
+   python -m open_banking.main open_banking/data/demo_provider.json --provider "Demo Provider"
+   ```
+
+### Using Your Own Provider Data
+
+You can point the CLI to any number of JSON files that match the structure used in `open_banking/data/demo_provider.json`. Each file represents a single bank or provider and contains a list of accounts with their transactions.
+
+### Notes
+
+- All data is stored locally and is for demonstration only.
+- The CLI validates that the JSON files exist before trying to read them.
+- Additional providers can be registered by adding more JSON files or by implementing custom provider classes.

--- a/open_banking/__init__.py
+++ b/open_banking/__init__.py
@@ -1,0 +1,6 @@
+"""Sample open banking package."""
+
+from .api import OpenBankingAPI
+from .providers import JsonFileProvider
+
+__all__ = ["OpenBankingAPI", "JsonFileProvider"]

--- a/open_banking/api.py
+++ b/open_banking/api.py
@@ -1,0 +1,77 @@
+"""Facade for interacting with multiple open banking providers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict
+from typing import Dict, Iterable, List, Sequence
+
+from .models import Account
+from .providers import BankingProvider
+
+
+class OpenBankingAPI:
+    """Simple orchestrator that aggregates accounts from multiple providers."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, BankingProvider] = {}
+
+    def register_provider(self, provider: BankingProvider) -> None:
+        """Register a provider by its name."""
+
+        if provider.name in self._providers:
+            raise ValueError(f"Provider '{provider.name}' already registered")
+        self._providers[provider.name] = provider
+
+    @property
+    def providers(self) -> Sequence[str]:
+        """Return the list of registered provider names."""
+
+        return tuple(self._providers.keys())
+
+    def accounts(self, provider: str | None = None) -> List[Account]:
+        """Return accounts, optionally filtered by provider name."""
+
+        providers: Iterable[BankingProvider]
+        if provider:
+            try:
+                providers = (self._providers[provider],)
+            except KeyError as exc:  # pragma: no cover - defensive branch
+                raise KeyError(f"Unknown provider '{provider}'") from exc
+        else:
+            providers = self._providers.values()
+
+        accounts: List[Account] = []
+        for item in providers:
+            accounts.extend(item.accounts())
+        return accounts
+
+    def aggregate_balances(self) -> Dict[str, float]:
+        """Return the total balance per currency across all providers."""
+
+        totals: Dict[str, float] = defaultdict(float)
+        for account in self.accounts():
+            totals[account.currency] += account.available_balance()
+        return dict(totals)
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of all accounts."""
+
+        return {
+            "providers": list(self.providers),
+            "accounts": [self._account_to_dict(account) for account in self.accounts()],
+            "balances": self.aggregate_balances(),
+        }
+
+    @staticmethod
+    def _account_to_dict(account: Account) -> dict:
+        serialisable = asdict(account)
+        serialisable["available_balance"] = account.available_balance()
+        serialisable["transactions"] = [
+            {**tx, "booking_date": tx["booking_date"].isoformat()}
+            for tx in serialisable["transactions"]
+        ]
+        return serialisable
+
+
+__all__ = ["OpenBankingAPI"]

--- a/open_banking/data/demo_provider.json
+++ b/open_banking/data/demo_provider.json
@@ -1,0 +1,87 @@
+{
+  "accounts": [
+    {
+      "id": "acc-001",
+      "name": "Everyday Checking",
+      "type": "checking",
+      "currency": "USD",
+      "balance": 1520.75,
+      "transactions": [
+        {
+          "id": "txn-001",
+          "description": "Salary",
+          "amount": 2500.00,
+          "currency": "USD",
+          "booking_date": "2024-03-28",
+          "category": "income"
+        },
+        {
+          "id": "txn-002",
+          "description": "Groceries",
+          "amount": -82.14,
+          "currency": "USD",
+          "booking_date": "2024-03-26",
+          "category": "food"
+        },
+        {
+          "id": "txn-003",
+          "description": "Rent",
+          "amount": -1200.00,
+          "currency": "USD",
+          "booking_date": "2024-03-25",
+          "category": "housing"
+        }
+      ]
+    },
+    {
+      "id": "acc-002",
+      "name": "Travel Savings",
+      "type": "savings",
+      "currency": "USD",
+      "balance": 3240.10,
+      "transactions": [
+        {
+          "id": "txn-101",
+          "description": "Interest Payment",
+          "amount": 5.12,
+          "currency": "USD",
+          "booking_date": "2024-03-30",
+          "category": "interest"
+        },
+        {
+          "id": "txn-102",
+          "description": "Flight Booking",
+          "amount": -450.00,
+          "currency": "USD",
+          "booking_date": "2024-03-15",
+          "category": "travel"
+        }
+      ]
+    },
+    {
+      "id": "acc-003",
+      "name": "Shared Expenses",
+      "type": "joint",
+      "currency": "EUR",
+      "balance": 980.00,
+      "transactions": [
+        {
+          "id": "txn-201",
+          "description": "Utility Bill",
+          "amount": -120.50,
+          "currency": "EUR",
+          "booking_date": "2024-03-20",
+          "category": "utilities"
+        },
+        {
+          "id": "txn-202",
+          "description": "Dinner",
+          "amount": -64.80,
+          "currency": "EUR",
+          "booking_date": "2024-03-18",
+          "category": "food"
+        }
+      ]
+    }
+  ]
+}

--- a/open_banking/main.py
+++ b/open_banking/main.py
@@ -1,0 +1,95 @@
+"""Command line interface for the sample open banking application."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from .api import OpenBankingAPI
+from .providers import JsonFileProvider
+
+
+def configure_api(data_paths: List[Path]) -> OpenBankingAPI:
+    api = OpenBankingAPI()
+    for path in data_paths:
+        provider_name = path.stem.replace("_", " ").title()
+        api.register_provider(JsonFileProvider(provider_name, path))
+    return api
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sample Open Banking CLI")
+    parser.add_argument(
+        "data",
+        nargs="+",
+        type=Path,
+        help="Path(s) to provider JSON definitions",
+    )
+    parser.add_argument(
+        "--provider",
+        help="Filter results for a specific provider name",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output format",
+    )
+    return parser
+
+
+def format_table(api: OpenBankingAPI, provider: str | None) -> str:
+    accounts = api.accounts(provider)
+    if not accounts:
+        return "No accounts found."
+
+    headers = ("Provider", "Account", "Type", "Currency", "Balance", "Available")
+    table = [headers]
+    for account in accounts:
+        table.append(
+            (
+                account.provider,
+                account.name,
+                account.type,
+                account.currency,
+                f"{account.balance:,.2f}",
+                f"{account.available_balance():,.2f}",
+            )
+        )
+
+    col_widths = [max(len(str(row[idx])) for row in table) for idx in range(len(headers))]
+    lines = []
+    for row in table:
+        lines.append(
+            " | ".join(str(value).ljust(col_widths[idx]) for idx, value in enumerate(row))
+        )
+    return "\n".join(lines)
+
+
+def format_json(api: OpenBankingAPI, provider: str | None) -> str:
+    data = api.to_dict()
+    if provider:
+        data["accounts"] = [account for account in data["accounts"] if account["provider"] == provider]
+    return json.dumps(data, indent=2)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    data_paths = [path.expanduser().resolve() for path in args.data]
+    missing_files = [str(path) for path in data_paths if not path.exists()]
+    if missing_files:
+        raise SystemExit(f"Missing provider files: {', '.join(missing_files)}")
+
+    api = configure_api(data_paths)
+    if args.format == "table":
+        print(format_table(api, args.provider))
+    else:
+        print(format_json(api, args.provider))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/open_banking/models.py
+++ b/open_banking/models.py
@@ -1,0 +1,37 @@
+"""Data models for the sample open banking application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import List, Optional
+
+
+@dataclass(slots=True)
+class Transaction:
+    """Represents a single financial transaction."""
+
+    id: str
+    description: str
+    amount: float
+    currency: str
+    booking_date: date
+    category: Optional[str] = None
+
+
+@dataclass(slots=True)
+class Account:
+    """Represents a bank account that can be retrieved via the API."""
+
+    id: str
+    name: str
+    type: str
+    currency: str
+    balance: float
+    provider: str
+    transactions: List[Transaction] = field(default_factory=list)
+
+    def available_balance(self) -> float:
+        """Return the current balance including all booked transactions."""
+
+        return self.balance + sum(t.amount for t in self.transactions)

--- a/open_banking/providers.py
+++ b/open_banking/providers.py
@@ -1,0 +1,77 @@
+"""Provider implementations for the sample open banking application."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import date
+from pathlib import Path
+from typing import Iterable, List, Protocol
+
+from .models import Account, Transaction
+
+
+class BankingProvider(Protocol):
+    """Protocol describing the behaviour of a banking data provider."""
+
+    name: str
+
+    def accounts(self) -> Iterable[Account]:
+        """Return the accounts exposed by the provider."""
+
+
+class JsonFileProvider:
+    """Simple provider that loads account data from a JSON file."""
+
+    def __init__(self, name: str, json_path: Path) -> None:
+        self.name = name
+        self._json_path = json_path
+        self._accounts: List[Account] = []
+
+    def accounts(self) -> Iterable[Account]:
+        if not self._accounts:
+            raw = json.loads(self._json_path.read_text(encoding="utf-8"))
+            self._accounts = [self._parse_account(item) for item in raw["accounts"]]
+        return list(self._accounts)
+
+    def _parse_account(self, raw: dict) -> Account:
+        transactions = [self._parse_transaction(t) for t in raw.get("transactions", [])]
+        account = Account(
+            id=raw["id"],
+            name=raw["name"],
+            type=raw.get("type", "unknown"),
+            currency=raw.get("currency", "EUR"),
+            balance=float(raw.get("balance", 0.0)),
+            provider=self.name,
+            transactions=transactions,
+        )
+        return account
+
+    @staticmethod
+    def _parse_transaction(raw: dict) -> Transaction:
+        return Transaction(
+            id=raw["id"],
+            description=raw.get("description", ""),
+            amount=float(raw.get("amount", 0.0)),
+            currency=raw.get("currency", "EUR"),
+            booking_date=date.fromisoformat(raw["booking_date"]),
+            category=raw.get("category"),
+        )
+
+    def export(self) -> dict:
+        """Return the provider data as a JSON serialisable dict."""
+
+        return {
+            "name": self.name,
+            "accounts": [self._account_to_dict(account) for account in self.accounts()],
+        }
+
+    @staticmethod
+    def _account_to_dict(account: Account) -> dict:
+        serialisable = asdict(account)
+        for transaction in serialisable["transactions"]:
+            transaction["booking_date"] = transaction["booking_date"].isoformat()
+        return serialisable
+
+
+__all__ = ["BankingProvider", "JsonFileProvider"]


### PR DESCRIPTION
## Summary
- add a simple open banking package with data models, provider loader, and aggregation API
- implement a CLI to render provider data as a table or JSON and bundle demo JSON data
- document how to run the sample application in the README

## Testing
- python -m open_banking.main open_banking/data/demo_provider.json

------
https://chatgpt.com/codex/tasks/task_e_68d7f6c8073483319623b91d483279d3